### PR TITLE
Change lower bound of min config to be 1 instead of 0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ There is an intention to expand this charms feature-set to include:
 * monitoring, 
 * statistics, 
 * an exposed service
+* scaling to/from 0 nodes
 
 Eventually it should be expanded to deploy just as the upstream helm charts suggest
 with the juju cloud-provider mainlined into the upstream source.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ juju_scale: '- {min: 3, max: 5, application: kubernetes-worker}'  # indicates 3 
 ```
 
 ```yaml
-# indicates 0 to 10 nodes of GPU based workers
+# indicates 1 to 10 nodes of GPU based workers
 juju_scale: '- {min: 1, max: 10, application: kubernetes-worker-gpu}'
 ```
 
 ```yaml
-# indicates 0 to 10 nodes of GPU based workers and 3 to 5 kubernetes-worker nodes
+# indicates 1 to 10 nodes of GPU based workers and 3 to 5 kubernetes-worker nodes
 juju_scale: |-
    - {min: 1, max: 10, application: kubernetes-worker-gpu}
    - {min: 3, max: 5, application: kubernetes-worker}

--- a/src/config/scale.py
+++ b/src/config/scale.py
@@ -26,7 +26,9 @@ def _validate(_min, _max, app, model, cfg):
     except ValueError:
         _min, _max = -1, -1
     if _min <= 0 or _max <= 0:
-        raise ConfigError(f"{ERROR} <min> & <max> must be non-negative, non-zero integers - '{cfg}'")
+        raise ConfigError(
+            f"{ERROR} <min> & <max> must be non-negative, non-zero integers - '{cfg}'"
+        )
     if _max <= _min:
         raise ConfigError(f"{ERROR} <min> should be less than <max> - '{cfg}'")
     return SimpleNamespace(min=_min, max=_max, model=model, application=app)

--- a/src/config/scale.py
+++ b/src/config/scale.py
@@ -25,8 +25,8 @@ def _validate(_min, _max, app, model, cfg):
         _min, _max = int(_min), int(_max)
     except ValueError:
         _min, _max = -1, -1
-    if _min < 0 or _max < 0:
-        raise ConfigError(f"{ERROR} <min> & <max> must be non-negative integers - '{cfg}'")
+    if _min <= 0 or _max <= 0:
+        raise ConfigError(f"{ERROR} <min> & <max> must be non-negative, non-zero integers - '{cfg}'")
     if _max <= _min:
         raise ConfigError(f"{ERROR} <min> should be less than <max> - '{cfg}'")
     return SimpleNamespace(min=_min, max=_max, model=model, application=app)

--- a/tests/data/pebble_cfg_minimum/layer.yaml
+++ b/tests/data/pebble_cfg_minimum/layer.yaml
@@ -1,6 +1,6 @@
 services:
   juju-autoscaler:
-    command: /cluster-autoscaler --namespace test_juju_autoscaler_pebble_ready_after_config_minimal --cloud-provider=juju --cloud-config=/config/cloud-config.yaml --nodes 0:3:cdcaed9f-336d-47d3-83ba-d9ea9047b18c:kubernetes-worker --scale-down-unneeded-time='5m0s' --v='5'
+    command: /cluster-autoscaler --namespace test_juju_autoscaler_pebble_ready_after_config_minimal --cloud-provider=juju --cloud-config=/config/cloud-config.yaml --nodes 1:3:cdcaed9f-336d-47d3-83ba-d9ea9047b18c:kubernetes-worker --scale-down-unneeded-time='5m0s' --v='5'
     override: replace
     startup: enabled
     summary: juju-autoscaler

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,7 +41,7 @@ def harness(request):
         ("default_model_uuid", "cdcaed9f-336d-47d3-83ba-d9ea9047b18c", "nope"),
         (
             "scale",
-            "- {min: 0, max: 1, application: kubernetes-worker}",
+            "- {min: 1, max: 2, application: kubernetes-worker}",
             "- {min: 1, max: 0, application: kubernetes-worker}",
         ),
     ],
@@ -116,7 +116,7 @@ def test_juju_autoscaler_pebble_ready_after_config_minimal(
                 "juju_username": "alice",
                 "juju_password": "secret",
                 "juju_default_model_uuid": "cdcaed9f-336d-47d3-83ba-d9ea9047b18c",
-                "juju_scale": "- {min: 0, max: 3, application: kubernetes-worker}",
+                "juju_scale": "- {min: 1, max: 3, application: kubernetes-worker}",
                 "juju_ca_cert": text,
                 "autoscaler_extra_args": "{v: 5, scale-down-unneeded-time: 5m0s}",
             }


### PR DESCRIPTION
This PR changes the lower bound of the min configuration option to be 1 instead of 0, as currently the juju autoscaler does not support scaling to and from 0 in a reliable way.