### PR TITLE
ignore not found errors when deleting manifest resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ kubectl taint node $NODE juju.is/kubernetes-control-plane=true:NoSchedule-
 
 Deploy the charm into a `k8s` type juju model (not a machine model)
 ```bash
-juju deploy kubernetes-autoscaler --constraints "tags=node.juju-application=kubernetes-control-plane"
+juju deploy kubernetes-autoscaler --trust --constraints "tags=node.juju-application=kubernetes-control-plane"
 ```
 
 Provide these as configuration to the deployed application

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,7 +87,7 @@ class KubernetesAutoscalerCharm(CharmBase):
 
         self.unit.status = WaitingStatus("Shutting down")
         manifests = Manifests(self)
-        manifests.delete_manifest(ignore_unauthorized=True)
+        manifests.delete_manifest(ignore_unauthorized=True, ignore_not_found=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the charm is restarted before the manifests are applied, then it will try to clean up resources that do not exist, resulting in a 404 not found API error from the lightkube client when the delete call is made. 

This situation occurred when deploying the charm, which then goes into a blocked state since its not configured,  and then trying to move it onto a control-plane node using:
```
kubectl patch statefulset kubernetes-autoscaler -p '{"spec": {"template": {"spec": {"nodeSelector": {"juju-application": "kubernetes-control-plane"}}}}}' -n autoscaler-model
```
The charm has yet to apply the manifests, but when it gets shutdown to be moved the stop hook runs which attempts to delete resources that were not created yet. 

A fix for this is to ignore 404 not found in the delete call. 
